### PR TITLE
feat: Make dart json generators explicitly call toJson()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'user.go.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class User {
 	@JsonKey(name: "ID")final int id;
 	@JsonKey(name: "Name")final String name;

--- a/examples/everything/everything.go.dart
+++ b/examples/everything/everything.go.dart
@@ -2,7 +2,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'everything.go.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Child {
 	final int id;
 	final String name;
@@ -17,7 +17,7 @@ class Child {
 	factory Child.fromJson(Map<String, dynamic> json) => _$ChildFromJson(json);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class Parent {
 	final String id;
 	final int number1;

--- a/examples/firestore/firestore.go.dart
+++ b/examples/firestore/firestore.go.dart
@@ -13,7 +13,7 @@ class _TimestampConverter implements JsonConverter<DateTime, Timestamp> {
   Timestamp toJson(DateTime object) => Timestamp.fromDate(object);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 @_TimestampConverter()
 class User {
 	final int id;

--- a/examples/multipackage/multipackage.go.dart
+++ b/examples/multipackage/multipackage.go.dart
@@ -13,7 +13,7 @@ class _TimestampConverter implements JsonConverter<DateTime, Timestamp> {
   Timestamp toJson(DateTime object) => Timestamp.fromDate(object);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 @_TimestampConverter()
 class Outer {
 	final String? id;

--- a/examples/user/user.go.dart
+++ b/examples/user/user.go.dart
@@ -2,7 +2,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'user.go.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class User {
 	@JsonKey(name: "ID")final int id;
 	@JsonKey(name: "Name")final String name;

--- a/generator/class.go
+++ b/generator/class.go
@@ -43,7 +43,7 @@ func generateDeserialization(wr io.Writer, ts *types.TypeName) {
 }
 
 func generateDartClass(outputFile io.Writer, ts *types.TypeName, st *types.Struct, registry *format.TypeFormatterRegistry, mode options.Mode) {
-	fmt.Fprintln(outputFile, "@JsonSerializable()")
+	fmt.Fprintln(outputFile, "@JsonSerializable(explicitToJson: true)")
 	if mode == options.Firestore {
 		fmt.Fprintln(outputFile, "@_TimestampConverter()")
 	}


### PR DESCRIPTION
When passing a class to jsonEncode() in dart it will traverse the json tree calling toJson() on all of the nested attributes. If, however, code calls toJson() on a class and expects it to be completely serialized it will fail because toJson() is not called on the nested attributes.

This commit sets the explicitToJson flag to true to fix this.

Related issue: https://github.com/google/json_serializable.dart/issues/57